### PR TITLE
docs: annotate source files with Rust-specific inline explanations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,14 @@
-//! Library crate for rust-samples-rocket-restful
+//! Library crate root for `rust-samples-rocket-restful`.
 //!
-//! This module exposes the core functionality for integration testing
-//! and potential reuse in other crates.
+//! Exposes the application's modules as a library so they can be imported by
+//! integration tests in the `tests/` directory without duplicating code.
+//!
+//! ## Rust note: binary vs library crates
+//! Rust allows a project to have both `main.rs` (binary crate — produces an
+//! executable) and `lib.rs` (library crate — exposes reusable modules). The
+//! binary imports from the library, and integration tests target the library
+//! directly. This is the standard Rocket testing pattern: tests instantiate
+//! the app via the library without starting a real HTTP server.
 
 pub mod models;
 pub mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,15 @@ mod state;
 
 use state::player_collection::{PlayerCollection, initialize_players};
 
-// ============================================================================
-// ROCKET LAUNCH
-// ============================================================================
-
+/// Configures and launches the Rocket web server.
+///
+/// ## Rust note: `#[launch]` macro
+/// `#[launch]` is a Rocket procedural macro that generates the actual `main()`
+/// function around this one. It sets up an async runtime (Tokio), calls
+/// `rocket()` to build the configured instance, and starts the HTTP server.
+///
+/// The `-> _` return type lets the compiler infer the full generic `Rocket<Build>`
+/// type, avoiding a verbose type annotation.
 #[launch]
 fn rocket() -> _ {
     let players = PlayerCollection::new(initialize_players());

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -1,11 +1,38 @@
-//! Player domain models and conversions.
+//! Player domain models and type mappings.
 //!
-//! Defines the player entity structures used for storage, API requests, and responses.
-//! Includes conversion implementations between different representations.
+//! This module defines the three representations of a player used across the
+//! application layers, and the mapping logic between them.
+//!
+//! ## Representations
+//!
+//! | Type              | Purpose                                     | Layer  |
+//! |-------------------|---------------------------------------------|--------|
+//! | [`Player`]        | Internal storage entity (includes ID)       | state  |
+//! | [`PlayerRequest`] | Inbound API payload (ID excluded)           | routes |
+//! | [`PlayerResponse`]| Outbound API payload (ID included)          | routes |
+//!
+//! ## Rust note: derive macros
+//!
+//! `#[derive(...)]` auto-generates standard trait implementations:
+//! - `Debug` — enables `{:?}` formatting for logging and tests
+//! - `Clone` — allows creating an independent copy of a value
+//! - `Serialize` — converts the struct to JSON (for API responses)
+//! - `Deserialize` — populates the struct from JSON (for API requests)
+//! - `#[serde(rename_all = "camelCase")]` maps snake_case Rust fields to
+//!   camelCase JSON keys (e.g. `first_name` → `"firstName"`)
 
 use rocket::serde::{Deserialize, Serialize};
 
-/// Internal Player entity for storage
+/// Internal entity stored in the in-memory collection.
+///
+/// This is the canonical representation used inside the application.
+/// It is never sent directly over the wire — API responses use [`PlayerResponse`].
+///
+/// ## Rust note: `Clone` + `Serialize` + `Deserialize`
+/// `Clone` is required because [`PlayerCollection`](crate::state::player_collection::PlayerCollection)
+/// is shared across threads via [`std::sync::Mutex`], and individual players
+/// are sometimes cloned when building responses. `Serialize` + `Deserialize`
+/// support reading and writing JSON (used for seed data).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Player {
@@ -22,7 +49,16 @@ pub struct Player {
     pub starting11: bool,
 }
 
-/// Request model for creating/updating players (no ID)
+/// Inbound payload for creating or updating a player.
+///
+/// Received as the JSON request body for `POST /players` and `PUT /players/{id}`.
+/// The `id` field is intentionally absent — it is either assigned automatically
+/// on creation, or taken from the URL path on update.
+///
+/// ## Rust note: missing `Clone` and `Serialize`
+/// This struct only needs `Deserialize` because it is only ever read from JSON.
+/// `Clone` and `Serialize` are omitted to keep the type minimal and make
+/// incorrect usage a compile-time error.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlayerRequest {
@@ -38,7 +74,14 @@ pub struct PlayerRequest {
     pub starting11: bool,
 }
 
-/// Response model for API output (includes ID)
+/// Outbound payload returned in API responses.
+///
+/// Returned as a JSON object for single-player endpoints, or as an element
+/// inside a `Vec<PlayerResponse>` for the list endpoint.
+///
+/// ## Rust note: missing `Deserialize`
+/// This struct only needs `Serialize` because it is only ever written to JSON.
+/// `Deserialize` is omitted since we never parse a response back into Rust.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlayerResponse {
@@ -55,14 +98,31 @@ pub struct PlayerResponse {
     pub starting11: bool,
 }
 
-// ============================================================================
-// CONVERSIONS
-// ============================================================================
+// These implementations describe how to map between player representations.
+// In Rust, mapping between types is done via the standard `From` trait, which
+// the language refers to as "type conversions" — but the term "mappings" is
+// used here to align with conventions familiar from other languages (e.g.
+// AutoMapper in .NET, MapStruct in Java).
+//
+// Two variants exist for the Player → PlayerResponse mapping:
+//
+//   From<Player>   — takes *ownership* of the source (moves it, no `.clone()` needed)
+//   From<&Player>  — *borrows* the source (reads without consuming it, `.clone()`
+//                    required for `String` fields since they cannot be moved out
+//                    of a shared reference)
 
 impl PlayerRequest {
-    /// Convert a PlayerRequest into a Player with the given ID.
+    /// Maps a [`PlayerRequest`] into a [`Player`] by consuming it.
     ///
-    /// Consumes the request to avoid cloning String fields.
+    /// The `id` parameter is the externally assigned identifier (auto-generated
+    /// on creation, or taken from the URL path on update).
+    ///
+    /// ## Rust note: `self` means ownership (move semantics)
+    /// `self` (without `&`) means the method takes *ownership* of the
+    /// `PlayerRequest`. The caller gives up the value — it cannot be used after
+    /// this call. In return, `String` fields are *moved* directly into the new
+    /// `Player` without any heap allocation, making this a zero-cost operation.
+    /// The borrow checker enforces this at compile time.
     pub fn into_player(self, id: u32) -> Player {
         Player {
             id,
@@ -81,6 +141,18 @@ impl PlayerRequest {
 }
 
 impl From<Player> for PlayerResponse {
+    /// Maps an owned [`Player`] into a [`PlayerResponse`].
+    ///
+    /// ## Rust note: owned mapping (move semantics, no `.clone()`)
+    /// `player` is passed by value, so Rust *moves* ownership into this
+    /// function. Each `String` field transfers its heap allocation directly
+    /// to the new `PlayerResponse` — no copying occurs. The original `Player`
+    /// is consumed and cannot be used after this call.
+    /// Primitive fields (`u32`, `bool`) implement the `Copy` trait, so they
+    /// are duplicated automatically without any explicit `.clone()`.
+    ///
+    /// Use this variant when the original `Player` is no longer needed after
+    /// the mapping (e.g. after removing it from the collection on update).
     fn from(player: Player) -> Self {
         PlayerResponse {
             id: player.id,
@@ -99,6 +171,19 @@ impl From<Player> for PlayerResponse {
 }
 
 impl From<&Player> for PlayerResponse {
+    /// Maps a borrowed [`Player`] reference into a [`PlayerResponse`].
+    ///
+    /// ## Rust note: borrow mapping (`.clone()` required for `String` fields)
+    /// `player` is a shared reference (`&Player`), so the original value is
+    /// *not* consumed — it remains usable after this call. However, because
+    /// Rust does not allow moving a value out of a reference that doesn't own
+    /// it, each `String` field must be `.clone()`d to allocate a new
+    /// independent copy on the heap.
+    /// Primitive fields (`u32`, `bool`) implement `Copy` and are duplicated
+    /// implicitly — no `.clone()` needed for them.
+    ///
+    /// Use this variant when the original `Player` must remain usable after
+    /// the mapping (e.g. when iterating over the collection to build a list).
     fn from(player: &Player) -> Self {
         PlayerResponse {
             id: player.id,

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,16 +1,27 @@
 //! Health check endpoint.
 //!
-//! Provides a simple endpoint for API health monitoring.
+//! Provides a simple liveness probe so load balancers and monitoring tools
+//! can verify that the API process is running and accepting connections.
 
 use rocket::{get, http::Status, routes};
 
+/// Returns `200 OK` if the service is running.
+///
+/// ## Rocket note: `#[get]` placement
+/// The `#[get("/health")]` attribute must appear *directly above* the function
+/// signature, with the doc comment (`///`) placed *above the attribute*. This
+/// order — doc comment → attribute → `fn` — is the Rust convention for all
+/// annotated items.
 #[get("/health")]
-/// Health check route returning 200 OK if the service is running
 fn health() -> Status {
     Status::Ok
 }
 
-/// Returns health check route
+/// Registers the health check route with Rocket.
+///
+/// Each route module exposes a `routes()` function that collects its handlers
+/// for mounting in [`main`](crate). This keeps route registration centralised
+/// and makes it easy to add or remove endpoints without touching `main.rs`.
 pub fn routes() -> Vec<rocket::Route> {
     routes![health]
 }

--- a/src/state/player_collection.rs
+++ b/src/state/player_collection.rs
@@ -1,18 +1,42 @@
-//! Player collection state and initialization.
+//! Thread-safe player collection state and seed data.
 //!
-//! Provides thread-safe storage for players using Mutex and initializes
-//! the collection with Argentina national team player data.
+//! Provides the storage type used across the whole application and seeds it
+//! with the Argentina 2022 World Cup squad at startup.
 
 use crate::models::player::Player;
 use std::sync::Mutex;
 
-/// Thread-safe player collection type
+/// Thread-safe player collection.
+///
+/// A type alias for `Mutex<Vec<Player>>`. Rocket shares application state
+/// across multiple async worker threads to handle concurrent requests.
+/// Wrapping the `Vec<Player>` in a [`std::sync::Mutex`] ensures that only
+/// one thread can read or modify the collection at a time, preventing data
+/// races.
+///
+/// ## Rust note: locking and `MutexGuard`
+/// Before accessing the inner `Vec`, callers must call `.lock()`:
+/// ```ignore
+/// let players = state.lock().map_err(|_| Status::InternalServerError)?;
+/// ```
+/// `lock()` blocks the current thread until no other thread holds the lock,
+/// then returns a `MutexGuard<Vec<Player>>`. The guard releases the lock
+/// automatically when it goes out of scope — this is the RAII pattern
+/// (Resource Acquisition Is Initialization), a core Rust idiom for
+/// deterministic resource cleanup without a garbage collector.
 pub type PlayerCollection = Mutex<Vec<Player>>;
 
-/// Initialize players with Argentina national team data.
+/// Seeds the player collection with the Argentina 2022 World Cup squad (26 players).
 ///
-/// Creates a typed collection of 26 players from the Argentina squad,
-/// eliminating the need for external JSON file loading.
+/// Called once at startup in [`main`](crate). Returns a plain `Vec<Player>`,
+/// which is then wrapped in a [`PlayerCollection`] (i.e. `Mutex`) before
+/// being handed to Rocket's state management via `.manage()`.
+///
+/// ## Rust note: `to_string()`
+/// String *literals* (`&str`, e.g. `"Martínez"`) are static references to
+/// read-only data baked into the binary. `.to_string()` allocates a new
+/// heap-owned `String`, which is required because the `Player` struct
+/// fields must own their data independently of the literal's lifetime.
 pub fn initialize_players() -> Vec<Player> {
     vec![
         Player {


### PR DESCRIPTION
Add inline doc comments explaining ownership, borrowing, move semantics, derive macros, Mutex/RAII, trait implementations, and the lib vs bin crate split for developers approaching this codebase from other languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced crate-level documentation with integration testing patterns and library-first usage guidance
  * Improved endpoint and module documentation for clarity and usability

* **New Features**
  * Public API expanded with `services` and `state` modules
  * Added player data conversion methods for request-to-entity and entity-to-response transformations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->