### PR TITLE
chore(data): normalize player dataset to 2022 FIFA World Cup Argentina squad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Normalize player dataset: correct Fernández/Mac Allister/Messi team data, replace hardcoded random UUIDs with deterministic UUID v5 values (namespace FIFA_WORLD_CUP_QATAR_2022_ARGENTINA_SQUAD)
+- Align CRUD test fixtures: Lo Celso (squad 27) for Create and Delete, Messi (squad 10) for Retrieve, Damián Martínez (squad 23) for Update
+
+## [0.1.0] - 2025-01-01
+
+### Added
+- Initial release: REST API for managing football players built with Rust and Rocket
+- CRUD operations with in-memory thread-safe storage (`Mutex<Vec<Player>>`)
+- Argentina 2022 World Cup squad seed data (26 players)
+- Layered architecture: routes → services → state
+- Integration tests following Arrange/Act/Assert pattern

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "rust-samples-rocket-restful"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rocket",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-samples-rocket-restful"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/state/player_collection.rs
+++ b/src/state/player_collection.rs
@@ -40,7 +40,7 @@ pub type PlayerCollection = Mutex<Vec<Player>>;
 pub fn initialize_players() -> Vec<Player> {
     vec![
         Player {
-            id: "f28c863b-48fd-4f41-834f-e49ee16d048a".to_string(),
+            id: "01772c59-43f0-5d85-b913-c78e4e281452".to_string(),
             first_name: "Damián".to_string(),
             middle_name: "Emiliano".to_string(),
             last_name: "Martínez".to_string(),
@@ -53,7 +53,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "45765a8a-78df-45ab-8d91-9d1a49d38d7a".to_string(),
+            id: "da31293b-4c7e-5e0f-a168-469ee29ecbc4".to_string(),
             first_name: "Nahuel".to_string(),
             middle_name: "".to_string(),
             last_name: "Molina".to_string(),
@@ -66,7 +66,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "d3ab3b82-90c1-463f-ba71-78edf4b6cdce".to_string(),
+            id: "c096c69e-762b-5281-9290-bb9c167a24a0".to_string(),
             first_name: "Cristian".to_string(),
             middle_name: "Gabriel".to_string(),
             last_name: "Romero".to_string(),
@@ -79,7 +79,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "cee9bb3e-3737-4d12-9f27-f3941be01642".to_string(),
+            id: "d5f7dd7a-1dcb-5960-ba27-e34865b63358".to_string(),
             first_name: "Nicolás".to_string(),
             middle_name: "Hernán Gonzalo".to_string(),
             last_name: "Otamendi".to_string(),
@@ -92,7 +92,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "a98b2337-5f2e-4f93-b30f-0969b7ccde47".to_string(),
+            id: "2f6f90a0-9b9d-5023-96d2-a2aaf03143a6".to_string(),
             first_name: "Nicolás".to_string(),
             middle_name: "Alejandro".to_string(),
             last_name: "Tagliafico".to_string(),
@@ -105,7 +105,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "1e9bcf7c-7cf0-4535-ab4f-2bec5c6777e3".to_string(),
+            id: "b5b46e79-929e-5ed2-949d-0d167109c022".to_string(),
             first_name: "Ángel".to_string(),
             middle_name: "Fabián".to_string(),
             last_name: "Di María".to_string(),
@@ -118,7 +118,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "36980293-8dea-4f43-95ba-8067fa71591c".to_string(),
+            id: "0293b282-1da8-562e-998e-83849b417a42".to_string(),
             first_name: "Rodrigo".to_string(),
             middle_name: "Javier".to_string(),
             last_name: "de Paul".to_string(),
@@ -131,7 +131,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "fcf653d9-c74d-4757-adb2-dcf46cbc2825".to_string(),
+            id: "d3ba552a-dac3-588a-b961-1ea7224017fd".to_string(),
             first_name: "Enzo".to_string(),
             middle_name: "Jeremías".to_string(),
             last_name: "Fernández".to_string(),
@@ -139,12 +139,12 @@ pub fn initialize_players() -> Vec<Player> {
             squad_number: 24,
             position: "Central Midfield".to_string(),
             abbr_position: "CM".to_string(),
-            team: "Chelsea FC".to_string(),
-            league: "Premier League".to_string(),
+            team: "SL Benfica".to_string(),
+            league: "Liga Portugal".to_string(),
             starting11: true,
         },
         Player {
-            id: "5cd7d768-dde8-4037-90a6-50d541a98577".to_string(),
+            id: "9613cae9-16ab-5b54-937e-3135123b9e0d".to_string(),
             first_name: "Alexis".to_string(),
             middle_name: "".to_string(),
             last_name: "Mac Allister".to_string(),
@@ -152,12 +152,12 @@ pub fn initialize_players() -> Vec<Player> {
             squad_number: 20,
             position: "Central Midfield".to_string(),
             abbr_position: "CM".to_string(),
-            team: "Liverpool FC".to_string(),
+            team: "Brighton & Hove Albion".to_string(),
             league: "Premier League".to_string(),
             starting11: true,
         },
         Player {
-            id: "f10f398d-b2ff-40aa-acac-51f58d129bc7".to_string(),
+            id: "acc433bf-d505-51fe-831e-45eb44c4d43c".to_string(),
             first_name: "Lionel".to_string(),
             middle_name: "Andrés".to_string(),
             last_name: "Messi".to_string(),
@@ -165,12 +165,12 @@ pub fn initialize_players() -> Vec<Player> {
             squad_number: 10,
             position: "Right Winger".to_string(),
             abbr_position: "RW".to_string(),
-            team: "Inter Miami CF".to_string(),
-            league: "Major League Soccer".to_string(),
+            team: "Paris Saint-Germain".to_string(),
+            league: "Ligue 1".to_string(),
             starting11: true,
         },
         Player {
-            id: "80d61421-93a1-466c-82dc-81152b677c22".to_string(),
+            id: "38bae91d-8519-55a2-b30a-b9fe38849bfb".to_string(),
             first_name: "Julián".to_string(),
             middle_name: "".to_string(),
             last_name: "Álvarez".to_string(),
@@ -183,7 +183,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: true,
         },
         Player {
-            id: "2c3ec9a0-a1b3-4e34-82e0-7413be4bc77f".to_string(),
+            id: "5a9cd988-95e6-54c1-bc34-9aa08acca8d0".to_string(),
             first_name: "Franco".to_string(),
             middle_name: "Daniel".to_string(),
             last_name: "Armani".to_string(),
@@ -196,7 +196,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "3f5dcba2-4b86-4704-a020-2f2c2a8875f8".to_string(),
+            id: "c62f2ac1-41e8-5d34-b073-2ba0913d0e31".to_string(),
             first_name: "Gerónimo".to_string(),
             middle_name: "".to_string(),
             last_name: "Rulli".to_string(),
@@ -209,7 +209,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "378e11b8-76b2-4886-b2c9-f686edaa7d5e".to_string(),
+            id: "5fdb10e8-38c0-5084-9a3f-b369a960b9c2".to_string(),
             first_name: "Juan".to_string(),
             middle_name: "Marcos".to_string(),
             last_name: "Foyth".to_string(),
@@ -222,7 +222,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "f4daee32-549a-43cb-9214-20034bb00a7d".to_string(),
+            id: "bbd441f7-fcfb-5834-8468-2a9004b64c8c".to_string(),
             first_name: "Gonzalo".to_string(),
             middle_name: "Ariel".to_string(),
             last_name: "Montiel".to_string(),
@@ -235,7 +235,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "ac5b20a4-96e5-45e2-9089-bcc5a37f93c0".to_string(),
+            id: "d8bfea25-f189-5d5e-b3a5-ed89329b9f7c".to_string(),
             first_name: "Germán".to_string(),
             middle_name: "Alejo".to_string(),
             last_name: "Pezzella".to_string(),
@@ -248,7 +248,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "409d5d12-e993-4a40-9e73-c054a06565dc".to_string(),
+            id: "dca343a8-12e5-53d6-89a8-916b120a5ee4".to_string(),
             first_name: "Marcos".to_string(),
             middle_name: "Javier".to_string(),
             last_name: "Acuña".to_string(),
@@ -261,7 +261,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "8f0b631f-f95d-40cc-8a59-61bbd82f6de5".to_string(),
+            id: "98306555-a466-5d18-804e-dc82175e697b".to_string(),
             first_name: "Lisandro".to_string(),
             middle_name: "".to_string(),
             last_name: "Martínez".to_string(),
@@ -274,7 +274,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "d7a342b5-8e96-415b-9c97-c2f80dbc33b6".to_string(),
+            id: "9d140400-196f-55d8-86e1-e0b96a375c83".to_string(),
             first_name: "Leandro".to_string(),
             middle_name: "Daniel".to_string(),
             last_name: "Paredes".to_string(),
@@ -287,7 +287,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "e395e764-0140-4c41-a9bb-ced7652a64ae".to_string(),
+            id: "d3b0e8e8-2c34-531a-b608-b24fed0ef986".to_string(),
             first_name: "Exequiel".to_string(),
             middle_name: "Alejandro".to_string(),
             last_name: "Palacios".to_string(),
@@ -300,7 +300,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "170b46d5-2a34-408d-8595-7aea1a047c0c".to_string(),
+            id: "7cc8d527-56a2-58bd-9528-2618fc139d30".to_string(),
             first_name: "Alejandro".to_string(),
             middle_name: "Darío".to_string(),
             last_name: "Gómez".to_string(),
@@ -313,7 +313,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "3fe5ca9c-5887-4432-8f8b-b60a1a93b626".to_string(),
+            id: "191c82af-0c51-526a-b903-c3600b61b506".to_string(),
             first_name: "Guido".to_string(),
             middle_name: "".to_string(),
             last_name: "Rodríguez".to_string(),
@@ -326,7 +326,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "79439ba4-5f97-441f-8612-f3957058f99c".to_string(),
+            id: "b1306b7b-a3a4-5f7c-90fd-dd5bdbed57ba".to_string(),
             first_name: "Ángel".to_string(),
             middle_name: "Martín".to_string(),
             last_name: "Correa".to_string(),
@@ -339,7 +339,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "a9ebeb5f-3ca4-42f6-9a80-c723556e00fa".to_string(),
+            id: "ecec27e8-487b-5622-b116-0855020477ed".to_string(),
             first_name: "Thiago".to_string(),
             middle_name: "Ezequiel".to_string(),
             last_name: "Almada".to_string(),
@@ -352,7 +352,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "dcc142ca-2e76-49b6-b9d1-d7ae7d7110f2".to_string(),
+            id: "7941cd7c-4df1-5952-97e8-1e7f5d08e8aa".to_string(),
             first_name: "Paulo".to_string(),
             middle_name: "Exequiel".to_string(),
             last_name: "Dybala".to_string(),
@@ -365,7 +365,7 @@ pub fn initialize_players() -> Vec<Player> {
             starting11: false,
         },
         Player {
-            id: "87a135a2-3634-49b9-b4b0-21a8b80f2b9d".to_string(),
+            id: "79c96f29-c59f-5f98-96b8-3a5946246624".to_string(),
             first_name: "Lautaro".to_string(),
             middle_name: "Javier".to_string(),
             last_name: "Martínez".to_string(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,29 +12,31 @@ use rust_samples_rocket_restful::{
 };
 
 // Seed UUID for Lionel Messi — matches the value in player_collection.rs
-pub const SEED_MESSI_ID: &str = "f10f398d-b2ff-40aa-acac-51f58d129bc7";
+pub const SEED_MESSI_ID: &str = "acc433bf-d505-51fe-831e-45eb44c4d43c";
 
-// Test Fixture: Thiago Almada — squad 16, reserved for POST (create) tests
+// Test Fixture: Giovani Lo Celso — squad 27, reserved for POST (create) and DELETE tests.
+// Lo Celso was in Argentina's preliminary squad for Qatar 2022 before injury.
+// Squad 27 sits outside the seeded 1–26 range, so creation never conflicts with seed data.
 pub fn player_request_for_creation() -> PlayerRequest {
     PlayerRequest {
-        first_name: "Thiago".to_string(),
-        middle_name: "Ezequiel".to_string(),
-        last_name: "Almada".to_string(),
-        date_of_birth: "2001-04-26T00:00:00.000Z".to_string(),
-        squad_number: 16,
-        position: "Attacking Midfield".to_string(),
-        abbr_position: "AM".to_string(),
-        team: "Atlanta United FC".to_string(),
-        league: "Major League Soccer".to_string(),
+        first_name: "Giovani".to_string(),
+        middle_name: "".to_string(),
+        last_name: "Lo Celso".to_string(),
+        date_of_birth: "1996-07-09T00:00:00.000Z".to_string(),
+        squad_number: 27,
+        position: "Central Midfield".to_string(),
+        abbr_position: "CM".to_string(),
+        team: "Real Betis Balompié".to_string(),
+        league: "La Liga".to_string(),
         starting11: false,
     }
 }
 
-// Returns the full 26-player seed minus squad 16, so POST tests can create
-// Thiago Almada (squad 16) without hitting a duplicate-squad-number conflict.
+// Returns the full 26-player seed minus squad 27, so POST tests can create
+// Lo Celso (squad 27) without hitting a duplicate-squad-number conflict.
 pub fn players_except_player_for_creation() -> Vec<Player> {
     initialize_players()
         .into_iter()
-        .filter(|p| p.squad_number != 16)
+        .filter(|p| p.squad_number != 27)
         .collect()
 }

--- a/tests/player_routes_tests.rs
+++ b/tests/player_routes_tests.rs
@@ -21,8 +21,8 @@ fn setup_client() -> Client {
     Client::tracked(rocket).expect("valid rocket instance")
 }
 
-// 25-player seed (squad 16 excluded) — used by POST creation tests so the
-// canonical Thiago Almada fixture (squad 16) does not conflict
+// 26-player seed (squad 27 excluded) — used by POST creation tests so the
+// canonical Lo Celso fixture (squad 27) does not conflict
 fn setup_client_for_post() -> Client {
     let players = PlayerCollection::new(common::players_except_player_for_creation());
     let rocket = rocket::build()
@@ -32,18 +32,18 @@ fn setup_client_for_post() -> Client {
     Client::tracked(rocket).expect("valid rocket instance")
 }
 
-// JSON mirror of common::player_request_for_creation() — Thiago Almada, squad 16
+// JSON mirror of common::player_request_for_creation() — Giovani Lo Celso, squad 27
 fn player_request_for_creation_json() -> serde_json::Value {
     serde_json::json!({
-        "firstName": "Thiago",
-        "middleName": "Ezequiel",
-        "lastName": "Almada",
-        "dateOfBirth": "2001-04-26T00:00:00.000Z",
-        "squadNumber": 16,
-        "position": "Attacking Midfield",
-        "abbrPosition": "AM",
-        "team": "Atlanta United FC",
-        "league": "Major League Soccer",
+        "firstName": "Giovani",
+        "middleName": "",
+        "lastName": "Lo Celso",
+        "dateOfBirth": "1996-07-09T00:00:00.000Z",
+        "squadNumber": 27,
+        "position": "Central Midfield",
+        "abbrPosition": "CM",
+        "team": "Real Betis Balompié",
+        "league": "La Liga",
         "starting11": false
     })
 }
@@ -142,8 +142,8 @@ fn test_request_get_player_by_id_existing_response_status_ok() {
     assert_eq!(body["squadNumber"], 10);
     assert_eq!(body["position"], "Right Winger");
     assert_eq!(body["abbrPosition"], "RW");
-    assert_eq!(body["team"], "Inter Miami CF");
-    assert_eq!(body["league"], "Major League Soccer");
+    assert_eq!(body["team"], "Paris Saint-Germain");
+    assert_eq!(body["league"], "Ligue 1");
     assert_eq!(body["starting11"], true);
 }
 
@@ -179,8 +179,8 @@ fn test_request_get_player_by_squadnumber_existing_response_status_ok() {
     assert_eq!(body["dateOfBirth"], "1987-06-24T00:00:00.000Z");
     assert_eq!(body["position"], "Right Winger");
     assert_eq!(body["abbrPosition"], "RW");
-    assert_eq!(body["team"], "Inter Miami CF");
-    assert_eq!(body["league"], "Major League Soccer");
+    assert_eq!(body["team"], "Paris Saint-Germain");
+    assert_eq!(body["league"], "Ligue 1");
     assert_eq!(body["starting11"], true);
 }
 
@@ -200,7 +200,7 @@ fn test_request_get_player_by_squadnumber_nonexistent_response_status_not_found(
 // POST /players with valid body returns 201 Created with full player response
 #[test]
 fn test_request_post_player_body_valid_response_status_created() {
-    // Arrange — 25-player seed (no squad 16), so Thiago Almada can be created
+    // Arrange — 26-player seed (no squad 27), so Lo Celso can be created
     let client = setup_client_for_post();
     let body = player_request_for_creation_json();
     // Act
@@ -215,29 +215,34 @@ fn test_request_post_player_body_valid_response_status_created() {
         serde_json::from_str(&response.into_string().unwrap()).unwrap();
     assert!(!response_body["id"].as_str().unwrap().is_empty());
     assert_eq!(response_body["id"].as_str().unwrap().len(), 36); // UUID v4
-    assert_eq!(response_body["firstName"], "Thiago");
-    assert_eq!(response_body["middleName"], "Ezequiel");
-    assert_eq!(response_body["lastName"], "Almada");
-    assert_eq!(response_body["dateOfBirth"], "2001-04-26T00:00:00.000Z");
-    assert_eq!(response_body["squadNumber"], 16);
-    assert_eq!(response_body["position"], "Attacking Midfield");
-    assert_eq!(response_body["abbrPosition"], "AM");
-    assert_eq!(response_body["team"], "Atlanta United FC");
-    assert_eq!(response_body["league"], "Major League Soccer");
+    assert_eq!(response_body["firstName"], "Giovani");
+    assert_eq!(response_body["middleName"], "");
+    assert_eq!(response_body["lastName"], "Lo Celso");
+    assert_eq!(response_body["dateOfBirth"], "1996-07-09T00:00:00.000Z");
+    assert_eq!(response_body["squadNumber"], 27);
+    assert_eq!(response_body["position"], "Central Midfield");
+    assert_eq!(response_body["abbrPosition"], "CM");
+    assert_eq!(response_body["team"], "Real Betis Balompié");
+    assert_eq!(response_body["league"], "La Liga");
     assert_eq!(response_body["starting11"], false);
 }
 
 // POST /players with duplicate squad number returns 409 Conflict
 #[test]
 fn test_request_post_player_body_duplicate_response_status_conflict() {
-    // Arrange — full 26-player seed, squad 16 already present
+    // Arrange — POST Lo Celso once, then attempt a second creation (squad 27 now exists)
     let client = setup_client();
-    let body = player_request_for_creation_json(); // squad 16 — conflicts with seed
+    let body = player_request_for_creation_json();
+    client
+        .post("/players")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
     // Act
     let response = client
         .post("/players")
         .header(ContentType::JSON)
-        .body(body.to_string())
+        .body(player_request_for_creation_json().to_string())
         .dispatch();
     // Assert
     assert_eq!(response.status(), Status::Conflict);
@@ -301,10 +306,15 @@ fn test_request_put_player_squadnumber_nonexistent_response_status_not_found() {
 // DELETE /players/squadnumber/{squad_number} with existing number returns 204
 #[test]
 fn test_request_delete_player_squadnumber_existing_response_status_no_content() {
-    // Arrange
+    // Arrange — POST Lo Celso (squad 27) first, then delete by squad number
     let client = setup_client();
-    // Act — Alejandro Gómez wears squad_number 17
-    let response = client.delete("/players/squadnumber/17").dispatch();
+    client
+        .post("/players")
+        .header(ContentType::JSON)
+        .body(player_request_for_creation_json().to_string())
+        .dispatch();
+    // Act
+    let response = client.delete("/players/squadnumber/27").dispatch();
     // Assert
     assert_eq!(response.status(), Status::NoContent);
 }

--- a/tests/player_service_tests.rs
+++ b/tests/player_service_tests.rs
@@ -6,26 +6,28 @@ use rust_samples_rocket_restful::models::player::{Player, PlayerRequest};
 use rust_samples_rocket_restful::services::player_service::{self, CreateError, UpdateError};
 use rust_samples_rocket_restful::state::player_collection::initialize_players;
 
-// Returns 25 Argentina players (excluding Thiago Almada, reserved for creation tests)
+// Returns 26 Argentina players (excluding Lo Celso, reserved for creation tests)
 fn players_except_player_for_creation() -> Vec<Player> {
     initialize_players()
         .into_iter()
-        .filter(|p| p.squad_number != 16)
+        .filter(|p| p.squad_number != 27)
         .collect()
 }
 
-// Test Fixture: Thiago Almada - Used for POST (create) tests
+// Test Fixture: Giovani Lo Celso — squad 27, reserved for POST (create) and DELETE tests.
+// Lo Celso was in Argentina's preliminary squad for Qatar 2022 before injury.
+// Squad 27 sits outside the seeded 1–26 range, so creation never conflicts with seed data.
 fn player_request_for_creation() -> PlayerRequest {
     PlayerRequest {
-        first_name: "Thiago".to_string(),
-        middle_name: "Ezequiel".to_string(),
-        last_name: "Almada".to_string(),
-        date_of_birth: "2001-04-26T00:00:00.000Z".to_string(),
-        squad_number: 16,
-        position: "Attacking Midfield".to_string(),
-        abbr_position: "AM".to_string(),
-        team: "Atlanta United FC".to_string(),
-        league: "Major League Soccer".to_string(),
+        first_name: "Giovani".to_string(),
+        middle_name: "".to_string(),
+        last_name: "Lo Celso".to_string(),
+        date_of_birth: "1996-07-09T00:00:00.000Z".to_string(),
+        squad_number: 27,
+        position: "Central Midfield".to_string(),
+        abbr_position: "CM".to_string(),
+        team: "Real Betis Balompié".to_string(),
+        league: "La Liga".to_string(),
         starting11: false,
     }
 }
@@ -64,7 +66,7 @@ fn test_request_get_players_all_response_body_players() {
 }
 
 // Seed UUID for Lionel Messi — matches the value in player_collection.rs
-const SEED_MESSI_ID: &str = "f10f398d-b2ff-40aa-acac-51f58d129bc7";
+const SEED_MESSI_ID: &str = "acc433bf-d505-51fe-831e-45eb44c4d43c";
 
 // GET /players/{uuid} ---------------------------------------------------------
 
@@ -86,8 +88,8 @@ fn test_request_get_player_id_existing_response_body_player() {
     assert_eq!(player.squad_number, 10);
     assert_eq!(player.position, "Right Winger");
     assert_eq!(player.abbr_position, "RW");
-    assert_eq!(player.team, "Inter Miami CF");
-    assert_eq!(player.league, "Major League Soccer");
+    assert_eq!(player.team, "Paris Saint-Germain");
+    assert_eq!(player.league, "Ligue 1");
     assert!(player.starting11);
 }
 
@@ -122,8 +124,8 @@ fn test_request_get_player_squadnumber_existing_response_body_player() {
     assert_eq!(player.squad_number, 10);
     assert_eq!(player.position, "Right Winger");
     assert_eq!(player.abbr_position, "RW");
-    assert_eq!(player.team, "Inter Miami CF");
-    assert_eq!(player.league, "Major League Soccer");
+    assert_eq!(player.team, "Paris Saint-Germain");
+    assert_eq!(player.league, "Ligue 1");
     assert!(player.starting11);
 }
 
@@ -152,24 +154,25 @@ fn test_request_post_player_body_valid_response_body_created() {
     assert!(result.is_ok());
     let response = result.unwrap();
     assert!(!response.id.is_empty());
-    assert_eq!(response.first_name, "Thiago");
-    assert_eq!(response.middle_name, "Ezequiel");
-    assert_eq!(response.last_name, "Almada");
-    assert_eq!(response.date_of_birth, "2001-04-26T00:00:00.000Z");
-    assert_eq!(response.squad_number, 16);
-    assert_eq!(response.position, "Attacking Midfield");
-    assert_eq!(response.abbr_position, "AM");
-    assert_eq!(response.team, "Atlanta United FC");
-    assert_eq!(response.league, "Major League Soccer");
+    assert_eq!(response.first_name, "Giovani");
+    assert_eq!(response.middle_name, "");
+    assert_eq!(response.last_name, "Lo Celso");
+    assert_eq!(response.date_of_birth, "1996-07-09T00:00:00.000Z");
+    assert_eq!(response.squad_number, 27);
+    assert_eq!(response.position, "Central Midfield");
+    assert_eq!(response.abbr_position, "CM");
+    assert_eq!(response.team, "Real Betis Balompié");
+    assert_eq!(response.league, "La Liga");
     assert!(!response.starting11);
-    assert_eq!(players.len(), 26);
+    assert_eq!(players.len(), 27);
 }
 
 // POST /players/ with duplicate squad number returns 409 Conflict
 #[test]
 fn test_request_post_player_body_duplicate_response_status_conflict() {
-    // Arrange
+    // Arrange — insert Lo Celso first, then attempt a second creation
     let mut players = initialize_players();
+    player_service::create(&mut players, player_request_for_creation()).unwrap();
     let request = player_request_for_creation();
     // Act
     let result = player_service::create(&mut players, request);
@@ -179,7 +182,7 @@ fn test_request_post_player_body_duplicate_response_status_conflict() {
         result.unwrap_err(),
         CreateError::DuplicateSquadNumber
     ));
-    assert_eq!(players.len(), 26);
+    assert_eq!(players.len(), 27);
 }
 
 // POST /players/ with valid body assigns a non-empty UUID
@@ -272,14 +275,15 @@ fn test_request_put_player_squadnumber_existing_body_squad_number_immutable() {
 // DELETE /players/squadnumber/{squad_number} with existing squad number returns 204 No Content
 #[test]
 fn test_request_delete_player_squadnumber_existing_response_status_ok() {
-    // Arrange
+    // Arrange — insert Lo Celso (squad 27) first, then delete by squad number
     let mut players = initialize_players();
-    // Act — Alejandro Gómez wears squad_number 17
-    let result = player_service::delete(&mut players, 17);
+    player_service::create(&mut players, player_request_for_creation()).unwrap();
+    // Act
+    let result = player_service::delete(&mut players, 27);
     // Assert
     assert!(result);
-    assert_eq!(players.len(), 25);
-    assert!(player_service::get_by_squad_number(&players, 17).is_none());
+    assert_eq!(players.len(), 26);
+    assert!(player_service::get_by_squad_number(&players, 27).is_none());
 }
 
 // DELETE /players/squadnumber/{squad_number} with unknown squad number returns 404 Not Found


### PR DESCRIPTION
Closes #50

## Summary
- Replace all 26 hardcoded UUID v4 strings with canonical deterministic UUID v5 values (namespace `FIFA_WORLD_CUP_QATAR_2022_ARGENTINA_SQUAD`)
- Fix team/league data for Fernández (SL Benfica / Liga Portugal), Mac Allister (Brighton & Hove Albion), and Messi (Paris Saint-Germain / Ligue 1) to reflect November 2022 World Cup squads
- Align CRUD test fixtures: Lo Celso (squad 27) for Create and Delete, Messi (squad 10) for Retrieve, Damián Martínez (squad 23) for Update
- Bump version `0.1.0` → `0.2.0` and add `CHANGELOG.md`

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 33 tests pass (16 service, 13 routes, 4 concurrency)
- [x] `cargo build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected player dataset: updated team and league information for multiple players including key squad members.

* **Documentation**
  * Added comprehensive CHANGELOG documenting project history and changes using "Keep a Changelog" format with semantic versioning.

* **Chores**
  * Version bumped to 0.2.0.
  * Updated player identifiers throughout dataset.
  * Aligned test fixtures for consistent behavior across Create, Retrieve, Update, and Delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->