### PR TITLE
fix(routes): return 204 No Content on successful PUT (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CHANGELOG: added Ballon d'Or nominees list (A-Z) as release codenames (#26)
 
 ### Changed
+- `PUT /players/squadnumber/{squad_number}` now returns `204 No Content` with no body on success, aligning with all sibling repos (#63)
 - `initialize_database()` reads `STORAGE_PATH` environment variable for the database path, falling back to `storage/players-sqlite3.db` (#40)
 - README: added **Containers** section (`docker compose up/down`), fixed `Test the API` curl examples to use correct UUID and fixture data (#40)
 - SQLite persistence via `rusqlite` (bundled feature); database stored at `storage/players-sqlite3.db`

--- a/src/routes/players.rs
+++ b/src/routes/players.rs
@@ -122,7 +122,7 @@ fn create_player(
 /// JSON object with complete player data
 ///
 /// # Returns
-/// * `200 OK` - JSON object with updated player data
+/// * `204 No Content` - Player updated successfully, no body
 /// * `404 Not Found` - If no player has that squad number
 ///
 /// # Example
@@ -132,11 +132,11 @@ fn update_player(
     squad_number: u32,
     player_request: Json<PlayerRequest>,
     players: &State<PlayerCollection>,
-) -> Result<Json<PlayerResponse>, Status> {
+) -> Result<Status, Status> {
     let conn = players.lock().map_err(|_| Status::InternalServerError)?;
 
     match player_service::update(&conn, squad_number, player_request.into_inner()) {
-        Ok(response) => Ok(Json(response)),
+        Ok(_) => Ok(Status::NoContent),
         Err(UpdateError::NotFound) => Err(Status::NotFound),
         Err(UpdateError::Database(_)) => Err(Status::InternalServerError),
     }

--- a/tests/player_routes_tests.rs
+++ b/tests/player_routes_tests.rs
@@ -257,17 +257,11 @@ fn test_request_post_player_body_duplicate_response_status_conflict() {
 
 // PUT /players/squadnumber/{squad_number} -------------------------------------
 
-// PUT /players/squadnumber/{squad_number} returns 200 OK and preserves both
-// UUID and squad_number regardless of the values sent in the request body
+// PUT /players/squadnumber/{squad_number} returns 204 No Content on success
 #[test]
-fn test_request_put_player_squadnumber_existing_response_status_ok() {
-    // Arrange — capture the original UUID of squad 23 before the update
+fn test_request_put_player_squadnumber_existing_response_status_no_content() {
+    // Arrange
     let client = setup_client();
-    let original = client.get("/players/squadnumber/23").dispatch();
-    let original_body: serde_json::Value =
-        serde_json::from_str(&original.into_string().unwrap()).unwrap();
-    let original_id = original_body["id"].as_str().unwrap().to_string();
-    // Body carries squadNumber 99 — must be ignored; route param (23) wins
     let body = player_request_for_update_json();
     // Act
     let response = client
@@ -276,20 +270,7 @@ fn test_request_put_player_squadnumber_existing_response_status_ok() {
         .body(body.to_string())
         .dispatch();
     // Assert
-    assert_eq!(response.status(), Status::Ok);
-    let response_body: serde_json::Value =
-        serde_json::from_str(&response.into_string().unwrap()).unwrap();
-    assert_eq!(response_body["id"], original_id); // UUID preserved from record
-    assert_eq!(response_body["squadNumber"], 23); // natural key from route, not body
-    assert_eq!(response_body["firstName"], "Emiliano");
-    assert_eq!(response_body["middleName"], "");
-    assert_eq!(response_body["lastName"], "Martínez");
-    assert_eq!(response_body["dateOfBirth"], "1992-09-02T00:00:00.000Z");
-    assert_eq!(response_body["position"], "Goalkeeper");
-    assert_eq!(response_body["abbrPosition"], "GK");
-    assert_eq!(response_body["team"], "Aston Villa FC");
-    assert_eq!(response_body["league"], "Premier League");
-    assert_eq!(response_body["starting11"], true);
+    assert_eq!(response.status(), Status::NoContent);
 }
 
 // PUT /players/squadnumber/{squad_number} with nonexistent number returns 404


### PR DESCRIPTION
## Summary

- Changes `PUT /players/squadnumber/{squad_number}` handler return type from `Result<Json<PlayerResponse>, Status>` to `Result<Status, Status>`
- Returns `204 No Content` with no body on success, aligning with all five sibling repos (.NET, Java, TypeScript, Python, Go)
- Updates route test: asserts `204 No Content`, drops body assertions and pre-fetch

## Test plan

- [ ] `cargo test` — all 33 tests pass
- [ ] `PUT /players/squadnumber/{squad_number}` with existing squad number returns `204 No Content`
- [ ] `PUT /players/squadnumber/{squad_number}` with unknown squad number still returns `404 Not Found`

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Updates**
  * The `PUT /players/squadnumber/{squad_number}` endpoint now returns `204 No Content` with no response body on successful updates, replacing the previous `200 OK` response that included a JSON payload. This change aligns the endpoint with standard REST API conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->