### PR TITLE
feat(claude): add /pre-release slash command (#53)

### DIFF
--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -1,0 +1,117 @@
+Run the pre-release checklist for this project. Work through all three phases
+in order, pausing for explicit confirmation at each decision point before
+proceeding. Never create a branch, commit, tag, or push without approval.
+
+---
+
+## Phase 1 — Determine next release
+
+1. Run `git status` and confirm the working tree is clean and on `master`.
+   If not, stop and report the problem.
+
+2. Run `git tag --sort=-v:refname` to list existing tags. Identify the most
+   recent tag matching `v*.*.*-*` and extract its player codename.
+
+3. Read the A–Z player table from `CHANGELOG.md` to find the next player:
+   - **No tags yet**: start at `A` (first player in the table).
+   - **Normal case**: use the player that follows the last used codename
+     alphabetically. If letters were skipped, pick the next after the
+     highest existing codename — do not backfill gaps.
+   - **Last codename is `Z`** (Zlatan): the list is finite. Stop and flag
+     that the naming convention needs to be revisited before proceeding.
+
+4. Read the `[Unreleased]` section of `CHANGELOG.md` and infer the version
+   bump using these rules (applied in order — first match wins):
+   - If the `[Unreleased]` section has **no entries at all**, stop and report
+     that there is nothing to release — ask the user to add changelog entries
+     before proceeding.
+   - Any entry contains the word **BREAKING** (case-insensitive), a
+     `BREAKING CHANGE:` token in a commit footer, or a `!` suffix after
+     the commit type/scope (e.g. `feat!:` or `feat(scope)!:`) → **major** bump
+   - Any `### Added` subsection has entries → **minor** bump
+   - Otherwise (only `### Changed`, `### Fixed`, `### Removed`) → **patch** bump
+
+5. Compute the next version:
+   - **No tags yet** (step 2 found no matching tag): use `v0.1.0` as the base
+     version and apply the bump from step 4 (e.g. base `v0.1.0` + minor →
+     `v0.1.0`; base `v0.1.0` + major → `v1.0.0`). Always include the leading
+     `v` in the proposed tag.
+   - **Normal case**: apply the bump to the semver of the latest tag (e.g.
+     `v2.0.0-benzema` + minor → `v2.1.0-{next-player}`).
+
+6. Present a summary for confirmation before continuing:
+   - Last tag and player
+   - Next version and player codename
+   - Bump type and the reasoning (what triggered it)
+   - Proposed tag: `vX.Y.Z-{player}`
+   - Proposed branch: `release/vX.Y.Z-{player}`
+
+   **Wait for explicit approval before proceeding to Phase 2.**
+
+---
+
+## Phase 2 — Prepare release branch
+
+1. Create branch `release/vX.Y.Z-{player}` from `master`.
+
+2. Edit `CHANGELOG.md`:
+   - Replace `## [Unreleased]` with `## [X.Y.Z - PlayerName] - YYYY-MM-DD`
+     (use today's date; use the player's display name from the table, e.g.
+     "Benzema", "Cannavaro").
+   - Consolidate duplicate subsection headings (e.g. two `### Added` blocks
+     should be merged into one).
+   - Add a new empty `## [Unreleased]` section at the top (above the new
+     versioned heading) with the standard subsections.
+   - Update the compare links at the bottom of the file:
+     - `[unreleased]` → `.../compare/vX.Y.Z-{player}...HEAD`
+     - Add `[X.Y.Z - PlayerName]` → `.../compare/v{prev-tag}...vX.Y.Z-{player}`
+
+3. Show the full diff of `CHANGELOG.md` and propose this commit message:
+
+   ```bash
+   docs(changelog): prepare release notes for vX.Y.Z-{player} (#issue)
+   ```
+
+   **Wait for explicit approval before committing.**
+
+4. Run `/pre-commit`, manually skipping step 1 — do not re-run or re-attempt
+   the CHANGELOG update; it was already completed above. Open with: "Skip
+   step 1 — CHANGELOG was already updated as part of this release branch."
+   Proceed directly with steps 2–7.
+
+5. Propose opening a PR from `release/vX.Y.Z-{player}` into `master`.
+   **Wait for explicit approval before opening.**
+
+6. Open the PR with:
+   - Title: `docs(changelog): prepare release notes for vX.Y.Z-{player}`
+   - Body summarising what is included in this release.
+
+---
+
+## Phase 3 — Tag and release
+
+1. Wait — do not proceed until the user confirms:
+   - CI is green
+   - The PR has been merged into `master`
+
+2. Once confirmed, run:
+   ```bash
+   git checkout master && git pull origin master
+   ```
+   and show the resulting `git log --oneline -3`.
+
+3. Propose the annotated tag:
+   ```bash
+   git tag -a vX.Y.Z-{player} -m "Release X.Y.Z - PlayerName"
+   ```
+
+   **Wait for explicit approval before creating the tag.**
+
+4. Create the tag, then propose:
+   ```bash
+   git push origin vX.Y.Z-{player}
+   ```
+
+   **Wait for explicit approval before pushing.** Remind the user that pushing
+   the tag triggers the CD workflow which will build, publish the Docker image,
+   and create the GitHub Release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `.claude/commands/pre-release.md`: three-phase `/pre-release` slash command for determining next version, preparing release branch, and tagging (#53)
 - `rocket_okapi` integration: OpenAPI 3 spec auto-generated from route annotations; Swagger UI at `/swagger-ui/`, raw spec at `/openapi.json` (#39)
 - `Dockerfile` (multi-stage: `rust:1.88-slim-bookworm` builder → `debian:bookworm-slim` runtime), `compose.yaml`, `.dockerignore`, `scripts/entrypoint.sh`, and `scripts/healthcheck.sh` for container support (#40)
 - `rest/players.rest` with sample HTTP requests for all endpoints, compatible with VS Code REST Client and JetBrains HTTP Client (#40)


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/pre-release.md` implementing the `/pre-release` slash command
- Three-phase workflow: determine next version → prepare release branch → tag and release
- Reads Ballon d'Or naming convention from `CHANGELOG.md` A–Z table
- Infers version bump from `[Unreleased]` content (major/minor/patch rules)
- Explicit confirmation gates before every destructive action (branch, commit, tag, push)

## Test plan

- [x] Run `/pre-release` and verify Phase 1 summary is presented before any action is taken
- [x] Confirm version bump inference is correct based on `[Unreleased]` entries
- [x] Confirm next codename is read from the `CHANGELOG.md` table
- [x] Verify no branch, commit, tag, or push occurs without explicit approval

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)