### PR TITLE
test(players): normalize unknown scenario tests (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `UNKNOWN_PLAYER_ID` constant in `tests/common/mod.rs` for valid-UUID-absent-from-DB 404 scenarios (#69)
+- `unknown` test cases for GET `/players/{uuid}`, PUT and DELETE `/players/squadnumber/{n}` in `player_routes_tests.rs` (#69)
+- `unknown` test case for `get_by_id` at the service layer in `player_service_tests.rs` (#69)
+- `///` doc comments on all three player ID constants in `tests/common/mod.rs` documenting the `existing` / `nonexistent` / `unknown` vocabulary (#69)
+
 ### Changed
 
 ### Fixed

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,11 +8,17 @@
 
 use rust_samples_rocket_restful::models::player::PlayerRequest;
 
-// UUID of an existing player (Lionel Messi, squad 10) — matches the value seeded in player_collection.rs
+/// UUID of an existing player (Lionel Messi, squad 10) — matches the value seeded in player_collection.rs.
+/// Used in GET-by-UUID tests to verify a successful 200 OK lookup.
 pub const EXISTING_PLAYER_ID: &str = "acc433bf-d505-51fe-831e-45eb44c4d43c";
 
-// A well-formed UUID guaranteed not to exist in any seeded dataset
+/// A well-formed UUID guaranteed not to exist in any seeded dataset.
+/// Used in POST flows to represent a player absent from the database with a valid shape for creation.
 pub const NONEXISTENT_PLAYER_ID: &str = "00000000-0000-0000-0000-000000000000";
+
+/// A valid UUID format that is simply absent from the database.
+/// Used in GET/PUT/DELETE 404-by-lookup scenarios to verify Not Found handling.
+pub const UNKNOWN_PLAYER_ID: &str = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
 
 // Test Fixture: Giovani Lo Celso — squad 27, reserved for POST (create) and DELETE tests.
 // Lo Celso was in Argentina's preliminary squad for Qatar 2022 before injury.

--- a/tests/player_routes_tests.rs
+++ b/tests/player_routes_tests.rs
@@ -192,6 +192,19 @@ fn test_request_get_player_by_id_nonexistent_response_status_not_found() {
     assert_eq!(response.status(), Status::NotFound);
 }
 
+// GET /players/{uuid} with unknown UUID (valid format, absent from DB) returns 404 Not Found
+#[test]
+fn test_request_get_player_by_id_unknown_response_status_not_found() {
+    // Arrange
+    let client = setup_client();
+    // Act
+    let response = client
+        .get(format!("/players/{}", common::UNKNOWN_PLAYER_ID))
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::NotFound);
+}
+
 // GET /players/squadnumber/{squad_number} -------------------------------------
 
 // GET /players/squadnumber/{squad_number} with existing number returns 200 OK
@@ -320,6 +333,22 @@ fn test_request_put_player_squadnumber_nonexistent_response_status_not_found() {
     assert_eq!(response.status(), Status::NotFound);
 }
 
+// PUT /players/squadnumber/{squad_number} with unknown number (valid format, absent from DB) returns 404
+#[test]
+fn test_request_put_player_squadnumber_unknown_response_status_not_found() {
+    // Arrange
+    let client = setup_client();
+    let body = player_request_for_update_json();
+    // Act
+    let response = client
+        .put("/players/squadnumber/28")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::NotFound);
+}
+
 // DELETE /players/squadnumber/{squad_number} ----------------------------------
 
 // DELETE /players/squadnumber/{squad_number} with existing number returns 204
@@ -345,6 +374,17 @@ fn test_request_delete_player_squadnumber_nonexistent_response_status_not_found(
     let client = setup_client();
     // Act
     let response = client.delete("/players/squadnumber/999").dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::NotFound);
+}
+
+// DELETE /players/squadnumber/{squad_number} with unknown number (valid format, absent from DB) returns 404
+#[test]
+fn test_request_delete_player_squadnumber_unknown_response_status_not_found() {
+    // Arrange
+    let client = setup_client();
+    // Act
+    let response = client.delete("/players/squadnumber/28").dispatch();
     // Assert
     assert_eq!(response.status(), Status::NotFound);
 }

--- a/tests/player_service_tests.rs
+++ b/tests/player_service_tests.rs
@@ -66,6 +66,18 @@ fn test_request_get_player_id_nonexistent_response_body_none() {
     assert!(result.unwrap().is_none());
 }
 
+// GET /players/{uuid} with unknown UUID (valid format, absent from DB) returns None
+#[test]
+fn test_request_get_player_id_unknown_response_body_none() {
+    // Arrange
+    let connection = initialize_test_database();
+    // Act
+    let result = player_service::get_by_id(&connection, common::UNKNOWN_PLAYER_ID);
+    // Assert
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none());
+}
+
 // GET /players/squadnumber/{squad_number} ------------------------------------
 
 // GET /players/squadnumber/{squad_number} with existing number returns 200 OK


### PR DESCRIPTION
## Summary

- Adds `UNKNOWN_PLAYER_ID` constant to `tests/common/mod.rs` — a valid UUID format absent from the database, for 404-by-lookup scenarios
- Replaces `//` inline comments on all three player ID constants with `///` doc comments documenting the `existing` / `nonexistent` / `unknown` vocabulary
- Adds `unknown` test cases to `player_routes_tests.rs` for GET `/players/{uuid}`, PUT and DELETE `/players/squadnumber/{n}`
- Adds `unknown` test case for `get_by_id` at the service layer in `player_service_tests.rs`

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 38/38 passed
- [x] `cargo build` — success
- [x] `docker compose build` — success

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for API "not found" error scenarios across multiple endpoints to ensure robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->