### PR TITLE
docs(changelog): prepare release notes for v1.1.1-cannavaro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [1.1.1 - Cannavaro] - 2026-04-12
+
+### Added
+
 - CodeQL Advanced workflow (`.github/workflows/codeql.yml`) for static security analysis on push, pull request, and weekly schedule; covers `actions` and `rust` languages (#77)
 - Coverage reporting with `cargo-tarpaulin` and Codecov integration (#42)
 - `codecov.yml` with 80% minimum threshold on `src/services/`, `src/routes/`, `src/repositories/` (#42)
@@ -107,6 +117,7 @@ Release codenames follow an A-Z sequence using Ballon d'Or award nominees surnam
 | Y | `yayatoure` | Yaya Touré | Ivory Coast | 2011, 2013 |
 | Z | `zlatan` | Zlatan Ibrahimović | Sweden | 2013, 2015 |
 
-[unreleased]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.0-benzema...HEAD
+[unreleased]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.1-cannavaro...HEAD
+[1.1.1 - Cannavaro]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.0-benzema...v1.1.1-cannavaro
 [1.1.0 - Benzema]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.0.0-aguero...v1.1.0-benzema
 [1.0.0 - Agüero]: https://github.com/nanotaboada/rust-samples-rocket-restful/releases/tag/v1.0.0-aguero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- API Reference table in `README.md`: corrected `PUT /players/squadnumber/:squadnumber` response from `200 OK` to `204 No Content`
+
 ### Removed
 
 ## [1.1.1 - Cannavaro] - 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- API Reference table in `README.md`: corrected `PUT /players/squadnumber/:squadnumber` response from `200 OK` to `204 No Content`
-
 ### Removed
 
 ## [1.1.1 - Cannavaro] - 2026-04-12
@@ -36,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `codecov.yml` comment updated to reflect goal of maximum coverage on business logic layers (#78)
 
 ### Fixed
+
+- API Reference table in `README.md`: corrected `PUT /players/squadnumber/:squadnumber` response from `200 OK` to `204 No Content`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ graph RL
 | `GET` | `/players/:id` | Get player by ID | `200 OK` |
 | `GET` | `/players/squadnumber/:squadnumber` | Get player by squad number | `200 OK` |
 | `POST` | `/players` | Create new player | `201 Created` |
-| `PUT` | `/players/squadnumber/:squadnumber` | Update player by squad number | `200 OK` |
+| `PUT` | `/players/squadnumber/:squadnumber` | Update player by squad number | `204 No Content` |
 | `DELETE` | `/players/squadnumber/:squadnumber` | Remove player by squad number | `204 No Content` |
 | `GET` | `/health` | Health check | `200 OK` |
 


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` entries to `[1.1.1 - Cannavaro] - 2026-04-12` in `CHANGELOG.md`
- Adds new empty `[Unreleased]` section above the versioned heading
- Updates compare links at the bottom of `CHANGELOG.md`
- Fixes `PUT /players/squadnumber/:squadnumber` response code in `README.md` API Reference table (`200 OK` → `204 No Content`)

## What's in this release

**CI / tooling improvements (patch bump):**
- CodeQL Advanced workflow for static security analysis (#77)
- Coverage reporting with `cargo-tarpaulin` and Codecov integration (#42)
- `codecov.yml` with 80% minimum threshold and badge in `README.md` (#42)
- Consolidated CI lint jobs (#42)
- `[profile.release]` tuned for smaller binary size (#60)
- Docker builder switched to `musl` / Alpine for fully static binary (#57)
- Service error types aligned to `PlayerServiceError` across all operations (#56)
- `codecov.yml` ignore list and comment updated (#78)
- Pre-seeded `storage/` directory removed; migrations handle first-run init (#79)

## Test plan

- [x] CI passes on this PR
- [x] CHANGELOG diff is correct (no content lost, links updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected documented response status for PUT /players/squadnumber/:squadnumber from 200 OK to 204 No Content.

* **Documentation**
  * Added a new 1.1.1 release entry to the changelog and updated release comparison links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->