### PR TITLE
feat(routes): add payload validation, return 422 on failure (#97, #94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Field-level validation on `PlayerRequest` payloads using the `validator` crate (`#97`): all required string fields (`first_name`, `last_name`, `date_of_birth`, `position`, `abbr_position`, `team`, `league`) must be non-empty; `squad_number` must be in the range 1–99
+- Six new route-level integration tests covering validation failure scenarios for POST and PUT endpoints (`#97`)
+
 ### Changed
+
+- POST `/players` and PUT `/players/squadnumber/{squad_number}` now return `422 Unprocessable Entity` for field validation failures; `400 Bad Request` is reserved for malformed JSON / wrong `Content-Type` (`#94`, `#97`)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -160,6 +170,20 @@ dependencies = [
  "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -185,6 +209,17 @@ dependencies = [
  "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -288,6 +323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +433,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -619,6 +674,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +766,37 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -720,6 +888,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -931,6 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1136,30 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1060,6 +1267,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1212,6 +1431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -1467,6 +1687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "state"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1733,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1581,6 +1818,31 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1798,16 +2060,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna 1.1.0",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1819,6 +2114,36 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
+dependencies = [
+ "idna 0.5.0",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0bcf92720c40105ac4b2dda2a4ea3aa717d4d6a862cc217da653a4bd5c6b10"
+dependencies = [
+ "darling 0.20.11",
+ "once_cell",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2209,12 +2534,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 dependencies = [
  "is-terminal",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2231,6 +2585,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ diesel_migrations = "2.3"
 libsqlite3-sys = { version = "0.36", features = ["bundled"] }
 rocket_okapi = { version = "0.9.0", features = ["swagger"] }
 schemars     = { version = "1.2" }
+validator    = { version = "0.18", features = ["derive"] }
 
 [profile.release]
 lto           = true   # link-time optimisation — reduces binary size and improves inlining

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -26,6 +26,7 @@ use diesel::prelude::*;
 use rocket::serde::{Deserialize, Serialize};
 use rocket_okapi::okapi::schemars;
 use rocket_okapi::okapi::schemars::JsonSchema;
+use validator::Validate;
 
 /// Internal Diesel model for reading a row from the `players` table.
 ///
@@ -80,17 +81,25 @@ pub struct NewPlayer {
 /// This struct only needs `Deserialize` because it is only ever read from JSON.
 /// `Clone` and `Serialize` are omitted to keep the type minimal and make
 /// incorrect usage a compile-time error.
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct PlayerRequest {
+    #[validate(length(min = 1))]
     pub first_name: String,
     pub middle_name: String,
+    #[validate(length(min = 1))]
     pub last_name: String,
+    #[validate(length(min = 1))]
     pub date_of_birth: String,
+    #[validate(range(min = 1, max = 99))]
     pub squad_number: u32,
+    #[validate(length(min = 1))]
     pub position: String,
+    #[validate(length(min = 1))]
     pub abbr_position: String,
+    #[validate(length(min = 1))]
     pub team: String,
+    #[validate(length(min = 1))]
     pub league: String,
     pub starting11: bool,
 }

--- a/src/routes/players.rs
+++ b/src/routes/players.rs
@@ -17,6 +17,10 @@ use rocket::{State, delete, get, http::Status, post, put, serde::json::Json};
 use rocket_okapi::{openapi, openapi_get_routes_spec};
 use validator::Validate;
 
+fn validate_payload<T: Validate>(payload: &T) -> Result<(), Status> {
+    payload.validate().map_err(|_| Status::UnprocessableEntity)
+}
+
 /// GET /players - Retrieves all players in the collection.
 ///
 /// # Returns
@@ -107,9 +111,7 @@ fn create_player(
     players: &State<PlayerCollection>,
 ) -> Result<(Status, Json<PlayerResponse>), Status> {
     let payload = player_request.into_inner();
-    if payload.validate().is_err() {
-        return Err(Status::UnprocessableEntity);
-    }
+    validate_payload(&payload)?;
     let mut connection = players.get().map_err(|_| Status::InternalServerError)?;
 
     match player_service::create(&mut connection, payload) {
@@ -145,9 +147,7 @@ fn update_player(
     players: &State<PlayerCollection>,
 ) -> Result<Status, Status> {
     let payload = player_request.into_inner();
-    if payload.validate().is_err() {
-        return Err(Status::UnprocessableEntity);
-    }
+    validate_payload(&payload)?;
     let mut connection = players.get().map_err(|_| Status::InternalServerError)?;
 
     match player_service::update(&mut connection, squad_number, payload) {

--- a/src/routes/players.rs
+++ b/src/routes/players.rs
@@ -15,6 +15,7 @@ use crate::services::player_service::{self, CreateError, UpdateError};
 use crate::state::player_collection::PlayerCollection;
 use rocket::{State, delete, get, http::Status, post, put, serde::json::Json};
 use rocket_okapi::{openapi, openapi_get_routes_spec};
+use validator::Validate;
 
 /// GET /players - Retrieves all players in the collection.
 ///
@@ -105,9 +106,13 @@ fn create_player(
     player_request: Json<PlayerRequest>,
     players: &State<PlayerCollection>,
 ) -> Result<(Status, Json<PlayerResponse>), Status> {
+    let payload = player_request.into_inner();
+    if payload.validate().is_err() {
+        return Err(Status::UnprocessableEntity);
+    }
     let mut connection = players.get().map_err(|_| Status::InternalServerError)?;
 
-    match player_service::create(&mut connection, player_request.into_inner()) {
+    match player_service::create(&mut connection, payload) {
         Ok(response) => Ok((Status::Created, Json(response))),
         Err(CreateError::DuplicateSquadNumber) => Err(Status::Conflict),
         Err(CreateError::Database(_)) => Err(Status::InternalServerError),
@@ -139,9 +144,13 @@ fn update_player(
     player_request: Json<PlayerRequest>,
     players: &State<PlayerCollection>,
 ) -> Result<Status, Status> {
+    let payload = player_request.into_inner();
+    if payload.validate().is_err() {
+        return Err(Status::UnprocessableEntity);
+    }
     let mut connection = players.get().map_err(|_| Status::InternalServerError)?;
 
-    match player_service::update(&mut connection, squad_number, player_request.into_inner()) {
+    match player_service::update(&mut connection, squad_number, payload) {
         Ok(_) => Ok(Status::NoContent),
         Err(UpdateError::NotFound) => Err(Status::NotFound),
         Err(UpdateError::Database(_)) => Err(Status::InternalServerError),

--- a/tests/player_routes_tests.rs
+++ b/tests/player_routes_tests.rs
@@ -348,6 +348,175 @@ fn test_request_put_player_squadnumber_unknown_response_status_not_found() {
     assert_eq!(response.status(), Status::NotFound);
 }
 
+// POST /players — validation failures ----------------------------------------
+
+// POST /players with empty required string field returns 422 Unprocessable Entity
+#[test]
+fn test_request_post_players_body_empty_first_name_response_status_unprocessable_entity() {
+    // Arrange
+    let client = setup_client_for_post();
+    let body = serde_json::json!({
+        "firstName": "",
+        "middleName": "",
+        "lastName": "Lo Celso",
+        "dateOfBirth": "1996-07-09T00:00:00.000Z",
+        "squadNumber": 27,
+        "position": "Central Midfield",
+        "abbrPosition": "CM",
+        "team": "Real Betis Balompié",
+        "league": "La Liga",
+        "starting11": false
+    });
+    // Act
+    let response = client
+        .post("/players")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+}
+
+// POST /players with squad_number = 0 (below minimum) returns 422 Unprocessable Entity
+#[test]
+fn test_request_post_players_body_squad_number_zero_response_status_unprocessable_entity() {
+    // Arrange
+    let client = setup_client_for_post();
+    let body = serde_json::json!({
+        "firstName": "Giovani",
+        "middleName": "",
+        "lastName": "Lo Celso",
+        "dateOfBirth": "1996-07-09T00:00:00.000Z",
+        "squadNumber": 0,
+        "position": "Central Midfield",
+        "abbrPosition": "CM",
+        "team": "Real Betis Balompié",
+        "league": "La Liga",
+        "starting11": false
+    });
+    // Act
+    let response = client
+        .post("/players")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+}
+
+// POST /players with squad_number = 100 (above maximum) returns 422 Unprocessable Entity
+#[test]
+fn test_request_post_players_body_squad_number_above_maximum_response_status_unprocessable_entity()
+{
+    // Arrange
+    let client = setup_client_for_post();
+    let body = serde_json::json!({
+        "firstName": "Giovani",
+        "middleName": "",
+        "lastName": "Lo Celso",
+        "dateOfBirth": "1996-07-09T00:00:00.000Z",
+        "squadNumber": 100,
+        "position": "Central Midfield",
+        "abbrPosition": "CM",
+        "team": "Real Betis Balompié",
+        "league": "La Liga",
+        "starting11": false
+    });
+    // Act
+    let response = client
+        .post("/players")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+}
+
+// PUT /players/squadnumber/{squad_number} — validation failures ---------------
+
+// PUT /players/squadnumber/{squad_number} with empty required string field returns 422
+#[test]
+fn test_request_put_player_squadnumber_body_empty_last_name_response_status_unprocessable_entity() {
+    // Arrange
+    let client = setup_client();
+    let body = serde_json::json!({
+        "firstName": "Emiliano",
+        "middleName": "",
+        "lastName": "",
+        "dateOfBirth": "1992-09-02T00:00:00.000Z",
+        "squadNumber": 23,
+        "position": "Goalkeeper",
+        "abbrPosition": "GK",
+        "team": "Aston Villa FC",
+        "league": "Premier League",
+        "starting11": true
+    });
+    // Act
+    let response = client
+        .put("/players/squadnumber/23")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+}
+
+// PUT /players/squadnumber/{squad_number} with squad_number = 0 returns 422
+#[test]
+fn test_request_put_player_squadnumber_body_squad_number_zero_response_status_unprocessable_entity()
+{
+    // Arrange
+    let client = setup_client();
+    let body = serde_json::json!({
+        "firstName": "Emiliano",
+        "middleName": "",
+        "lastName": "Martínez",
+        "dateOfBirth": "1992-09-02T00:00:00.000Z",
+        "squadNumber": 0,
+        "position": "Goalkeeper",
+        "abbrPosition": "GK",
+        "team": "Aston Villa FC",
+        "league": "Premier League",
+        "starting11": true
+    });
+    // Act
+    let response = client
+        .put("/players/squadnumber/23")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+}
+
+// PUT /players/squadnumber/{squad_number} with squad_number = 100 returns 422
+#[test]
+fn test_request_put_player_squadnumber_body_squad_number_above_maximum_response_status_unprocessable_entity()
+ {
+    // Arrange
+    let client = setup_client();
+    let body = serde_json::json!({
+        "firstName": "Emiliano",
+        "middleName": "",
+        "lastName": "Martínez",
+        "dateOfBirth": "1992-09-02T00:00:00.000Z",
+        "squadNumber": 100,
+        "position": "Goalkeeper",
+        "abbrPosition": "GK",
+        "team": "Aston Villa FC",
+        "league": "Premier League",
+        "starting11": true
+    });
+    // Act
+    let response = client
+        .put("/players/squadnumber/23")
+        .header(ContentType::JSON)
+        .body(body.to_string())
+        .dispatch();
+    // Assert
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+}
+
 // DELETE /players/squadnumber/{squad_number} ----------------------------------
 
 // DELETE /players/squadnumber/{squad_number} with existing number returns 204

--- a/tests/player_routes_tests.rs
+++ b/tests/player_routes_tests.rs
@@ -355,18 +355,8 @@ fn test_request_put_player_squadnumber_unknown_response_status_not_found() {
 fn test_request_post_players_body_empty_first_name_response_status_unprocessable_entity() {
     // Arrange
     let client = setup_client_for_post();
-    let body = serde_json::json!({
-        "firstName": "",
-        "middleName": "",
-        "lastName": "Lo Celso",
-        "dateOfBirth": "1996-07-09T00:00:00.000Z",
-        "squadNumber": 27,
-        "position": "Central Midfield",
-        "abbrPosition": "CM",
-        "team": "Real Betis Balompié",
-        "league": "La Liga",
-        "starting11": false
-    });
+    let mut body = player_request_for_creation_json();
+    body["firstName"] = serde_json::json!("");
     // Act
     let response = client
         .post("/players")
@@ -382,18 +372,8 @@ fn test_request_post_players_body_empty_first_name_response_status_unprocessable
 fn test_request_post_players_body_squad_number_zero_response_status_unprocessable_entity() {
     // Arrange
     let client = setup_client_for_post();
-    let body = serde_json::json!({
-        "firstName": "Giovani",
-        "middleName": "",
-        "lastName": "Lo Celso",
-        "dateOfBirth": "1996-07-09T00:00:00.000Z",
-        "squadNumber": 0,
-        "position": "Central Midfield",
-        "abbrPosition": "CM",
-        "team": "Real Betis Balompié",
-        "league": "La Liga",
-        "starting11": false
-    });
+    let mut body = player_request_for_creation_json();
+    body["squadNumber"] = serde_json::json!(0);
     // Act
     let response = client
         .post("/players")
@@ -410,18 +390,8 @@ fn test_request_post_players_body_squad_number_above_maximum_response_status_unp
 {
     // Arrange
     let client = setup_client_for_post();
-    let body = serde_json::json!({
-        "firstName": "Giovani",
-        "middleName": "",
-        "lastName": "Lo Celso",
-        "dateOfBirth": "1996-07-09T00:00:00.000Z",
-        "squadNumber": 100,
-        "position": "Central Midfield",
-        "abbrPosition": "CM",
-        "team": "Real Betis Balompié",
-        "league": "La Liga",
-        "starting11": false
-    });
+    let mut body = player_request_for_creation_json();
+    body["squadNumber"] = serde_json::json!(100);
     // Act
     let response = client
         .post("/players")
@@ -439,18 +409,8 @@ fn test_request_post_players_body_squad_number_above_maximum_response_status_unp
 fn test_request_put_player_squadnumber_body_empty_last_name_response_status_unprocessable_entity() {
     // Arrange
     let client = setup_client();
-    let body = serde_json::json!({
-        "firstName": "Emiliano",
-        "middleName": "",
-        "lastName": "",
-        "dateOfBirth": "1992-09-02T00:00:00.000Z",
-        "squadNumber": 23,
-        "position": "Goalkeeper",
-        "abbrPosition": "GK",
-        "team": "Aston Villa FC",
-        "league": "Premier League",
-        "starting11": true
-    });
+    let mut body = player_request_for_update_json();
+    body["lastName"] = serde_json::json!("");
     // Act
     let response = client
         .put("/players/squadnumber/23")
@@ -467,18 +427,8 @@ fn test_request_put_player_squadnumber_body_squad_number_zero_response_status_un
 {
     // Arrange
     let client = setup_client();
-    let body = serde_json::json!({
-        "firstName": "Emiliano",
-        "middleName": "",
-        "lastName": "Martínez",
-        "dateOfBirth": "1992-09-02T00:00:00.000Z",
-        "squadNumber": 0,
-        "position": "Goalkeeper",
-        "abbrPosition": "GK",
-        "team": "Aston Villa FC",
-        "league": "Premier League",
-        "starting11": true
-    });
+    let mut body = player_request_for_update_json();
+    body["squadNumber"] = serde_json::json!(0);
     // Act
     let response = client
         .put("/players/squadnumber/23")
@@ -495,18 +445,8 @@ fn test_request_put_player_squadnumber_body_squad_number_above_maximum_response_
  {
     // Arrange
     let client = setup_client();
-    let body = serde_json::json!({
-        "firstName": "Emiliano",
-        "middleName": "",
-        "lastName": "Martínez",
-        "dateOfBirth": "1992-09-02T00:00:00.000Z",
-        "squadNumber": 100,
-        "position": "Goalkeeper",
-        "abbrPosition": "GK",
-        "team": "Aston Villa FC",
-        "league": "Premier League",
-        "starting11": true
-    });
+    let mut body = player_request_for_update_json();
+    body["squadNumber"] = serde_json::json!(100);
     // Act
     let response = client
         .put("/players/squadnumber/23")


### PR DESCRIPTION
## Summary

- Adds field-level validation to `PlayerRequest` using the `validator` crate (`#[derive(Validate)]`)
- Required string fields (`first_name`, `last_name`, `date_of_birth`, `position`, `abbr_position`, `team`, `league`) must be non-empty; `middle_name` is intentionally left unvalidated (optional)
- `squad_number` must be in range 1–99
- POST and PUT handlers now call `.validate()` before the service layer, returning `422 Unprocessable Entity` on failure; `400 Bad Request` remains reserved for malformed JSON

## Test plan

- [x] `test_request_post_players_body_empty_first_name_response_status_unprocessable_entity`
- [x] `test_request_post_players_body_squad_number_zero_response_status_unprocessable_entity`
- [x] `test_request_post_players_body_squad_number_above_maximum_response_status_unprocessable_entity`
- [x] `test_request_put_player_squadnumber_body_empty_last_name_response_status_unprocessable_entity`
- [x] `test_request_put_player_squadnumber_body_squad_number_zero_response_status_unprocessable_entity`
- [x] `test_request_put_player_squadnumber_body_squad_number_above_maximum_response_status_unprocessable_entity`
- [x] All 44 existing tests continue to pass
- [x] `cargo clippy` clean, `docker compose build` success, CodeRabbit: no findings

Closes #97
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input validation for player requests: required text fields must be non-empty and squad numbers must be 1–99.
  * API endpoints now return 422 Unprocessable Entity for request-body validation failures (400 reserved for malformed JSON/incorrect Content-Type).

* **Tests**
  * Added integration tests verifying 422 responses for invalid player request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->