### PR TITLE
docs(changelog): move naming table to top, add separators and template (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Ballon d'Or Nominees 🏅
+
+Release codenames follow an A-Z sequence using Ballon d'Or award nominees surnames:
+
+| # | Tag Name | Player | Country | Notable Year |
+|---|----------|--------|---------|--------------|
+| A | `aguero` | Sergio Agüero | Argentina | 2011 |
+| B | `benzema` | Karim Benzema | France | 2022 (Winner) |
+| C | `cannavaro` | Fabio Cannavaro | Italy | 2006 (Winner) |
+| D | `drogba` | Didier Drogba | Ivory Coast | 2010 |
+| E | `etoo` | Samuel Eto'o | Cameroon | 2005, 2006 |
+| F | `figo` | Luís Figo | Portugal | 2000 (Winner) |
+| G | `griezmann` | Antoine Griezmann | France | 2016, 2018 |
+| H | `haaland` | Erling Haaland | Norway | 2023 |
+| I | `iniesta` | Andrés Iniesta | Spain | 2010, 2012 |
+| J | `jorginho` | Jorginho | Italy | 2021 |
+| K | `kaka` | Kaká | Brazil | 2007 (Winner) |
+| L | `lewandowski` | Robert Lewandowski | Poland | 2020, 2021 |
+| M | `messi` | Lionel Messi | Argentina | 8× Winner |
+| N | `neymar` | Neymar | Brazil | 2015, 2017 |
+| O | `owen` | Michael Owen | England | 2001 (Winner) |
+| P | `pirlo` | Andrea Pirlo | Italy | 2007, 2011 |
+| Q | `quaresma` | Ricardo Quaresma | Portugal | 2008 |
+| R | `ronaldo` | Cristiano Ronaldo | Portugal | 5× Winner |
+| S | `salah` | Mohamed Salah | Egypt | 2018, 2019 |
+| T | `torres` | Fernando Torres | Spain | 2008 |
+| U | `umtiti` | Samuel Umtiti | France | 2018 |
+| V | `vandijk` | Virgil van Dijk | Netherlands | 2019 |
+| W | `weah` | George Weah | Liberia | 1995 (Winner) |
+| X | `xavi` | Xavi | Spain | 2009, 2010, 2011 |
+| Y | `yayatoure` | Yaya Touré | Ivory Coast | 2011, 2013 |
+| Z | `zlatan` | Zlatan Ibrahimović | Sweden | 2013, 2015 |
+
+---
+
 ## [Unreleased]
 
 ### Added
@@ -19,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Removed
+
+---
 
 ## [1.1.1 - Cannavaro] - 2026-04-12
 
@@ -46,6 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pre-seeded `storage/players-sqlite3.db` file and `storage/` directory from repository; Diesel `embed_migrations!()` initialises and seeds the database on first start (#79)
 - `storage/` and `.envrc` added to `.gitignore` to prevent runtime database files and local environment secrets from being tracked (#79)
+
+---
 
 ## [1.1.0 - Benzema] - 2026-04-08
 
@@ -85,44 +124,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rusqlite` dependency replaced by `diesel` + `diesel_migrations` + `libsqlite3-sys` (bundled) (#64)
 - Hand-written `create_schema`, `seed`, and `is_empty` functions in `player_collection.rs` (#64)
 
+---
+
 ## [1.0.0 - Agüero] - 2026-04-06
 
 Initial release. See [README.md](README.md) for complete feature list and documentation.
 
 ---
 
-## Ballon d'Or Nominees 🏅
+<!-- Template for new releases:
 
-Release codenames follow an A-Z sequence using Ballon d'Or award nominees surnames:
+## [X.Y.Z - SURNAME] - YYYY-MM-DD
 
-| # | Tag Name | Player | Country | Notable Year |
-|---|----------|--------|---------|--------------|
-| A | `aguero` | Sergio Agüero | Argentina | 2011 |
-| B | `benzema` | Karim Benzema | France | 2022 (Winner) |
-| C | `cannavaro` | Fabio Cannavaro | Italy | 2006 (Winner) |
-| D | `drogba` | Didier Drogba | Ivory Coast | 2010 |
-| E | `etoo` | Samuel Eto'o | Cameroon | 2005, 2006 |
-| F | `figo` | Luís Figo | Portugal | 2000 (Winner) |
-| G | `griezmann` | Antoine Griezmann | France | 2016, 2018 |
-| H | `haaland` | Erling Haaland | Norway | 2023 |
-| I | `iniesta` | Andrés Iniesta | Spain | 2010, 2012 |
-| J | `jorginho` | Jorginho | Italy | 2021 |
-| K | `kaka` | Kaká | Brazil | 2007 (Winner) |
-| L | `lewandowski` | Robert Lewandowski | Poland | 2020, 2021 |
-| M | `messi` | Lionel Messi | Argentina | 8× Winner |
-| N | `neymar` | Neymar | Brazil | 2015, 2017 |
-| O | `owen` | Michael Owen | England | 2001 (Winner) |
-| P | `pirlo` | Andrea Pirlo | Italy | 2007, 2011 |
-| Q | `quaresma` | Ricardo Quaresma | Portugal | 2008 |
-| R | `ronaldo` | Cristiano Ronaldo | Portugal | 5× Winner |
-| S | `salah` | Mohamed Salah | Egypt | 2018, 2019 |
-| T | `torres` | Fernando Torres | Spain | 2008 |
-| U | `umtiti` | Samuel Umtiti | France | 2018 |
-| V | `vandijk` | Virgil van Dijk | Netherlands | 2019 |
-| W | `weah` | George Weah | Liberia | 1995 (Winner) |
-| X | `xavi` | Xavi | Spain | 2009, 2010, 2011 |
-| Y | `yayatoure` | Yaya Touré | Ivory Coast | 2011, 2013 |
-| Z | `zlatan` | Zlatan Ibrahimović | Sweden | 2013, 2015 |
+### Added
+- New features
+
+### Changed
+- Changes in existing functionality
+
+### Deprecated
+- Soon-to-be removed features
+
+### Removed
+- Removed features
+
+### Fixed
+- Bug fixes
+
+### Security
+- Security vulnerability fixes
+
+-->
 
 [unreleased]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.1-cannavaro...HEAD
 [1.1.1 - Cannavaro]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.0-benzema...v1.1.1-cannavaro


### PR DESCRIPTION
## Summary

- Moved "Ballon d'Or Nominees" naming table to the top (after preamble, before `[Unreleased]`)
- Added `---` separators between all release sections
- Added `<!-- Template for new releases: -->` comment block before the reference links

## Test plan

- [x] Verify naming table appears at the top, before `## [Unreleased]`
- [x] Verify `---` separators present between all sections
- [x] Verify template comment present before reference links
- [x] Verify no other content changed

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized changelog with new "Ballon d'Or Nominees 🏅" section containing an A–Z reference table for nominees.
  * Added visual separators around the Unreleased section and between release sections.
  * Introduced HTML comment template to guide formatting of future release entries and subsections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->