### PR TITLE
docs(changelog): prepare release notes for v1.1.2-drogba

### DIFF
--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -28,8 +28,11 @@ proceeding. Never create a branch, commit, tag, or push without approval.
    - Any entry contains the word **BREAKING** (case-insensitive), a
      `BREAKING CHANGE:` token in a commit footer, or a `!` suffix after
      the commit type/scope (e.g. `feat!:` or `feat(scope)!:`) → **major** bump
-   - Any `### Added` subsection has entries → **minor** bump
-   - Otherwise (only `### Changed`, `### Fixed`, `### Removed`) → **patch** bump
+   - Any `### Added` entry introduces a **new endpoint, request parameter, or
+     client-visible API response** → **minor** bump. Test additions, documentation
+     (ADRs, README, Swagger regen), and internal tooling do **not** qualify.
+   - Otherwise (only `### Changed`, `### Fixed`, `### Removed`, or non-API
+     additions) → **patch** bump
 
 5. Compute the next version:
    - **No tags yet** (step 2 found no matching tag): use `v0.1.0` as the base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ Release codenames follow an A-Z sequence using Ballon d'Or award nominees surnam
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+---
+
+## [1.1.2 - Drogba] - 2026-05-02
+
+### Added
+
 - Field-level validation on `PlayerRequest` payloads using the `validator` crate (`#97`): all required string fields (`first_name`, `last_name`, `date_of_birth`, `position`, `abbr_position`, `team`, `league`) must be non-empty; `squad_number` must be in the range 1–99
 - Six new route-level integration tests covering validation failure scenarios for POST and PUT endpoints (`#97`)
 
@@ -156,7 +168,8 @@ Initial release. See [README.md](README.md) for complete feature list and docume
 
 -->
 
-[unreleased]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.1-cannavaro...HEAD
+[unreleased]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.2-drogba...HEAD
+[1.1.2 - Drogba]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.1-cannavaro...v1.1.2-drogba
 [1.1.1 - Cannavaro]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.1.0-benzema...v1.1.1-cannavaro
 [1.1.0 - Benzema]: https://github.com/nanotaboada/rust-samples-rocket-restful/compare/v1.0.0-aguero...v1.1.0-benzema
 [1.0.0 - Agüero]: https://github.com/nanotaboada/rust-samples-rocket-restful/releases/tag/v1.0.0-aguero


### PR DESCRIPTION
## Summary

- Aligns the `/pre-release` command's minor/patch bump rule with `go-samples-gin-restful`: `### Added` entries only trigger a minor bump when they introduce a new endpoint, request parameter, or client-visible API response; test additions and internal tooling qualify as patch
- Prepares release notes for `v1.1.2-drogba` (patch): field-level validation via the `validator` crate and six new integration tests covering 422 responses for POST and PUT

## What's included in this release

- Field-level validation on `PlayerRequest` payloads (`validator` crate, `#97`): required string fields must be non-empty; `squad_number` must be in range 1–99
- Six new route-level integration tests for validation failure scenarios on POST and PUT (`#97`)
- POST `/players` and PUT `/players/squadnumber/{squad_number}` now return `422 Unprocessable Entity` for field validation failures; `400 Bad Request` reserved for malformed JSON / wrong `Content-Type` (`#94`, `#97`)

## Test plan

- [ ] CI passes (fmt, clippy, tests, build)
- [ ] CHANGELOG diff is correct: `[Unreleased]` is empty, `[1.1.2 - Drogba]` section is present with today's date
- [ ] Compare links at the bottom of CHANGELOG are correct
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released version 1.1.2 with field-level validation rules and refined HTTP status codes: validation errors return 422, malformed JSON returns 400.

* **Chores**
  * Updated release automation to improve breaking change detection and refine version bump criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->