### PR TITLE
ci(coverage): use taiki-e/install-action for cargo-tarpaulin

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -114,7 +114,9 @@ jobs:
           key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin --version 0.35.2 --locked
+        uses: taiki-e/install-action@v2.81.8
+        with:
+          tool: cargo-tarpaulin@0.35.2
 
       - name: Generate coverage report
         run: cargo tarpaulin --out xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Release codenames follow an A-Z sequence using Ballon d'Or award nominees surnam
 
 ### Changed
 
+- Replace `cargo install cargo-tarpaulin` with `taiki-e/install-action@v2.81.8` in CI to use a pre-built binary and reduce coverage job runtime
 - Consolidated agent instructions from `.github/copilot-instructions.md` into `CLAUDE.md`; deleted the legacy split-file layout (`#112`)
 - Rewrote all stale `.coderabbit.yaml` path instructions to reflect the current Diesel/r2d2/SQLite architecture; removed all references to the old `Mutex<Vec<Player>>` in-memory design (`#112`)
 


### PR DESCRIPTION
## Summary

- Replaces `cargo install cargo-tarpaulin --version 0.35.2 --locked` with `taiki-e/install-action@v2.81.8` to download a pre-built binary instead of compiling from source
- Reduces coverage job runtime from ~5 minutes to seconds for the tarpaulin install step

## Test plan

- [ ] Coverage job completes successfully with the pre-built binary
- [ ] Codecov report is still uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)